### PR TITLE
[SCH-1491] Remove main client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "rails", "8.0.1"
 
 gem "bootsnap"
-gem "google-cloud-discovery_engine-v1beta", "<= 0.20.1"
+gem "google-cloud-discovery_engine-v1beta"
 gem "google-cloud-storage"
 gem "govuk_app_config"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,7 +718,7 @@ DEPENDENCIES
   brakeman
   byebug
   climate_control
-  google-cloud-discovery_engine-v1beta (<= 0.20.1)
+  google-cloud-discovery_engine-v1beta
   google-cloud-storage
   govuk_app_config
   govuk_test


### PR DESCRIPTION
# What's changed?

- Remove `google-cloud-discovery_engine` main client gem
- Unpin version of `google-cloud-discovery_engine-v1beta` gem

# Why?

Updates to these gems (google-cloud-discovery_engine and google-cloud-discovery_engine-v1beta) are not compatible.
Keeping these two gems separate is why this repo needed to be created in the first place.

Response from Google about the compatibility of the gems:

New versions of Google Cloud Discovery Engine Ruby client libraries, specifically google-cloud-discovery_engine-v1beta v0.21 and the main client google-cloud-discovery_engine v2.3.0, can cause errors due to incompatibility between the major and beta versions. This often happens because beta versions like v1beta are pre-GA and may not be fully compatible with stable, GA versions of the  main client.

When you use both v1beta and v2.3.0 clients in the same project, you may encounter issues where the libraries expect different API versions, data structures, or have conflicting dependencies, leading to errors at runtime. This is a common challenge with Google's client libraries, as their development stages (Alpha, Beta, and GA) have different stability guarantees and may not be backward-compatible with each other.