### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,28 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 3
+    exclude:
+      - govuk_app_config
+      - govuk_test
+      - plek
+      - rubocop-govuk
   open-pull-requests-limit: 10
+
 - package-ecosystem: docker
   directory: /
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 3
   ignore:
     - dependency-name: ruby
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 3
   open-pull-requests-limit: 10


### PR DESCRIPTION
Setting to 3 days as per the [suggested configuration](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#schedule-and-cooldown) 

Excluding internal dependencies, as they will have their own cooldown configured.

Jira ticket [SCH-2043](https://gov-uk.atlassian.net/browse/SCH-2043)

[SCH-2043]: https://gov-uk.atlassian.net/browse/SCH-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ