### PR TITLE
Don't run CI or deploy for changes to `.git**` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".git**"
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Standardising to match behaviour on search-api and search-admin. We don't want to run a deployment purely for changes to files whose path begins `.git`