### PR TITLE
Add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,12 @@
+name: Lint GitHub Actions
+on:
+  push:
+    paths: ['.github/**']
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          show-progress: false
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main


### PR DESCRIPTION
We should lint GitHub Actions as part of our CI process. Adding this workflow brings this repo in line with the other search repos.