### PR TITLE
[SCH-2073] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           show-progress: false
-      - uses: ruby/setup-ruby@v1.310.0
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
       - run: bin/rake


### PR DESCRIPTION
Pin non-alphagov/non-github actions

-As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha

JIRA Card: https://gov-uk.atlassian.net/browse/SCH-2073
