### PR TITLE
Rake task to report status of discovery engine evaluations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,11 @@ inherit_mode:
 # can't verify.
 RSpec/VerifiedDoubles:
   Enabled: false
+
+# Rake task to output a report using "puts", rather than fill up logs.
+Rails/Output:
+  Exclude:
+    - 'app/services/discovery_engine/quality/evaluations_reporter.rb'
 # **************************************************************
 # TRY NOT TO ADD OVERRIDES IN THIS FILE
 #

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -42,10 +42,15 @@ module DiscoveryEngine::Quality
         sorted(evaluations).each do |evaluation|
           sqs = sample_query_set_name(evaluation)
           name = evaluation.name
-          time = formatted_date(evaluation.create_time)
+          start_time = evaluation.try(:create_time)
+          end_time = evaluation.try(:end_time)
+          duration = formatted_duration(evaluation) if start_time && end_time
+
           puts "Sample query set: #{sqs}"
           puts "Evaluation: #{name}"
-          puts "Start time: #{time}"
+          puts "Start time: #{formatted_date(start_time)}" if start_time
+          puts "End time: #{formatted_date(end_time)}" if end_time
+          puts "Duration: #{duration} mins" if duration
           puts "No quality metrics!" if missing_quality_metrics?(evaluation)
           puts ""
         end
@@ -63,6 +68,13 @@ module DiscoveryEngine::Quality
       Google::Protobuf::Timestamp.new(data)
         .to_time
         .strftime("%Y-%m-%d %H:%M:%S")
+    end
+
+    def formatted_duration(evaluation)
+      time_start = Time.zone.at(evaluation.create_time.seconds, evaluation.create_time.nanos, :nsec)
+      time_end = Time.zone.at(evaluation.end_time.seconds, evaluation.end_time.nanos, :nsec)
+      time_difference_seconds = time_end - time_start
+      (time_difference_seconds / 60.0).round(3)
     end
 
     def sample_query_set_name(evaluation)

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -28,11 +28,11 @@ module DiscoveryEngine::Quality
   private
 
     def printout_evaluations(evaluations_hash)
-      evaluations_hash.each do |state, array_of_evaluations|
+      evaluations_hash.each do |state, evaluations|
         puts state
         puts "=============="
 
-        array_of_evaluations.each do |evaluation|
+        sorted(evaluations).each do |evaluation|
           sqs = sample_query_set_name(evaluation)
           name = evaluation.name
           time = formatted_date(evaluation.create_time)
@@ -41,6 +41,12 @@ module DiscoveryEngine::Quality
           puts "Start time: #{time}"
           puts ""
         end
+      end
+    end
+
+    def sorted(evaluations)
+      evaluations.sort do |a, b|
+        [sample_query_set_name(a), formatted_date(a.create_time)] <=> [sample_query_set_name(b), formatted_date(b.create_time)]
       end
     end
 

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -1,0 +1,50 @@
+module DiscoveryEngine::Quality
+  class EvaluationsReporter
+    def fetch_and_format
+      evaluations_grouped_by_state = {
+        FAILED: [],
+        SUCCEEDED: [],
+        PENDING: [],
+        RUNNING: [],
+      }
+
+      evaluation_service.list_evaluations(parent:).each do |evaluation|
+        evaluations_grouped_by_state.each_key do |state|
+          if evaluation.state == state
+            evaluations_grouped_by_state[state] << evaluation
+          end
+        end
+      end
+      printout_evaluations(evaluations_grouped_by_state)
+    end
+
+  private
+
+    def printout_evaluations(evaluations_hash)
+      evaluations_hash.each do |state, array_of_evaluations|
+        puts state
+        puts "=============="
+
+        array_of_evaluations.each do |evaluation|
+          sqs = sample_query_set_name(evaluation)
+          name = evaluation.name
+          puts "Sample query set: #{sqs}"
+          puts "Evaluation: #{name}"
+          puts ""
+        end
+      end
+    end
+
+    def sample_query_set_name(evaluation)
+      evaluation.evaluation_spec.query_set_spec.sample_query_set.split("/").last
+    end
+
+    def evaluation_service
+      @evaluation_service ||= DiscoveryEngine::Clients.evaluation_service
+    end
+
+    def parent
+      @parent ||= Rails.application.config.discovery_engine_default_location_name
+    end
+  end
+end

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -28,11 +28,20 @@ module DiscoveryEngine::Quality
         array_of_evaluations.each do |evaluation|
           sqs = sample_query_set_name(evaluation)
           name = evaluation.name
+          time = formatted_date(evaluation.create_time)
           puts "Sample query set: #{sqs}"
           puts "Evaluation: #{name}"
+          puts "Start time: #{time}"
           puts ""
         end
       end
+    end
+
+    def formatted_date(google_time_stamp)
+      data = { nanos: google_time_stamp.nanos, seconds: google_time_stamp.seconds }
+      Google::Protobuf::Timestamp.new(data)
+        .to_time
+        .strftime("%Y-%m-%d %H:%M:%S")
     end
 
     def sample_query_set_name(evaluation)

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -46,6 +46,7 @@ module DiscoveryEngine::Quality
           puts "Sample query set: #{sqs}"
           puts "Evaluation: #{name}"
           puts "Start time: #{time}"
+          puts "No quality metrics!" if missing_quality_metrics?(evaluation)
           puts ""
         end
       end
@@ -66,6 +67,12 @@ module DiscoveryEngine::Quality
 
     def sample_query_set_name(evaluation)
       evaluation.evaluation_spec.query_set_spec.sample_query_set.split("/").last
+    end
+
+    def missing_quality_metrics?(evaluation)
+      return unless evaluation.state == :SUCCEEDED
+
+      evaluation.quality_metrics.to_h.values.all?(&:empty?)
     end
 
     def evaluation_service

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -1,7 +1,14 @@
 module DiscoveryEngine::Quality
   class EvaluationsReporter
     # date_string format is "2026-02"
-    def fetch_and_format(date_string: nil, states: [])
+    def initialize(date_string: nil, states: [])
+      @date_string = date_string
+      @states = states
+    end
+
+    attr_reader :date_string, :states
+
+    def fetch_and_format
       evaluations_grouped_by_state = {
         FAILED: [],
         SUCCEEDED: [],

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -1,13 +1,17 @@
 module DiscoveryEngine::Quality
   class EvaluationsReporter
     # date_string format is "2026-02"
-    def fetch_and_format(date_string: nil)
+    def fetch_and_format(date_string: nil, states: [])
       evaluations_grouped_by_state = {
         FAILED: [],
         SUCCEEDED: [],
         PENDING: [],
         RUNNING: [],
       }
+
+      if states.present?
+        evaluations_grouped_by_state.select! { |k, _v| states.include?(k) }
+      end
 
       evaluation_service.list_evaluations(parent:).each do |evaluation|
         next if date_string && !formatted_date(evaluation.create_time).include?(date_string)

--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -1,6 +1,7 @@
 module DiscoveryEngine::Quality
   class EvaluationsReporter
-    def fetch_and_format
+    # date_string format is "2026-02"
+    def fetch_and_format(date_string: nil)
       evaluations_grouped_by_state = {
         FAILED: [],
         SUCCEEDED: [],
@@ -9,6 +10,8 @@ module DiscoveryEngine::Quality
       }
 
       evaluation_service.list_evaluations(parent:).each do |evaluation|
+        next if date_string && !formatted_date(evaluation.create_time).include?(date_string)
+
         evaluations_grouped_by_state.each_key do |state|
           if evaluation.state == state
             evaluations_grouped_by_state[state] << evaluation

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,6 +1,6 @@
 namespace :report do
   # Outputs a list of evaluations of GOV.UK site search quality fetched from the Google DiscoveryEngine API's evaluations endpoint.
-  # The task can be called with no arguments, or with two arguments.
+  #  The task can be called with no arguments, or with two arguments.
   # Example usage:
   # rake report:evaluations['2026-06','failed pending'] will fetch pending and failed evaluations created in June 2026.
   # rake report:evaluations['','failed pending'] will fetch all failed and pending evaluations

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,6 @@
+namespace :report do
+  desc "Output evaluations report"
+  task evaluations: :environment do
+    # to be implemented
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,6 +1,27 @@
 namespace :report do
+  # Outputs a list of evaluations of GOV.UK site search quality fetched from the Google DiscoveryEngine API's evaluations endpoint.
+  # The task can be called with no arguments, or with two arguments.
+  # Example usage:
+  # rake report:evaluations['2026-06','failed pending'] will fetch pending and failed evaluations created in June 2026.
+  # rake report:evaluations['','failed pending'] will fetch all failed and pending evaluations
+  # rake report:evaluations['2026-06',''] will fetch all evaluations created in June 2026
+  # rake report:evaluations will fetch all evaluations
+
   desc "Output evaluations report"
-  task evaluations: :environment do
-    # to be implemented
+  task :evaluations, %i[date_string states] => :environment do |_, args|
+    valid_date_regex = /^\d{4}-\d{2}$/
+    valid_states = %i[FAILED PENDING RUNNING SUCCEEDED]
+
+    if args[:date_string]
+      date_string = args[:date_string]
+      raise "date_string must be in the format yyyy-mm" unless date_string.match(valid_date_regex)
+    end
+
+    if args[:states]
+      states = args[:states].split(" ").map { |arg| arg.upcase.to_sym }
+      raise "state must be one of #{valid_states.to_sentence}" unless (states - valid_states).empty?
+    end
+
+    DiscoveryEngine::Quality::EvaluationsReporter.new(date_string:, states:).fetch_and_format
   end
 end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "Report tasks" do
+  describe "report:evaluations" do
+    let(:reporter) { instance_double(DiscoveryEngine::Quality::EvaluationsReporter) }
+    let(:task) { Rake::Task["report:evaluations"] }
+
+    before do
+      task.reenable
+
+      allow(DiscoveryEngine::Quality::EvaluationsReporter).to receive(:new)
+        .with(anything)
+        .and_return(reporter)
+      allow(reporter).to receive(:fetch_and_format)
+    end
+
+    it "does not require arguments" do
+      expect { task.invoke }.not_to raise_error
+    end
+
+    it "raises an error if date string is not formatted correctly" do
+      expect { task.invoke("2027-1") }.to raise_error(RuntimeError)
+    end
+
+    it "raises an error if the format is not valid" do
+      expect { task.invoke("", "invalid") }.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -1,0 +1,77 @@
+require "google/cloud/discovery_engine/v1beta"
+
+RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
+  let(:evaluation_reporter) { described_class.new }
+
+  let(:binary_evaluation_name) { "projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3" }
+
+  let(:binary_set_name) { "projects/123456/locations/global/sampleQuerySets/binary_2025-12" }
+
+  let(:binary_query_set_spec) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec::QuerySetSpec", sample_query_set: binary_set_name)
+  end
+
+  let(:binary_evaluation_spec) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec", query_set_spec: binary_query_set_spec)
+  end
+
+  let(:clickstream_evaluation_name) { "projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9" }
+
+  let(:clickstream_set_name) { "projects/123456/locations/global/sampleQuerySets/clickstream_2025-12" }
+
+  let(:clickstream_query_set_spec) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec::QuerySetSpec", sample_query_set: clickstream_set_name)
+  end
+
+  let(:clickstream_evaluation_spec) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec", query_set_spec: clickstream_query_set_spec)
+  end
+
+  let(:evaluation_success) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
+           name: binary_evaluation_name,
+           evaluation_spec: binary_evaluation_spec,
+           state: :SUCCEEDED,
+           error: {})
+  end
+
+  let(:evaluation_failure) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
+           name: clickstream_evaluation_name,
+           evaluation_spec: clickstream_evaluation_spec,
+           state: :FAILED,
+           error: { code: 13, message: "Internal error encountered. Please try again. If the issue persists, please contact our support team." })
+  end
+
+  let(:mock_client) { double(::Google::Cloud::DiscoveryEngine::V1beta::EvaluationService::Client) }
+  let(:mock_list_evaluations_response) { double(Gapic::PagedEnumerable) }
+
+  before do
+    allow(DiscoveryEngine::Clients).to receive(:evaluation_service).and_return(mock_client)
+    allow(mock_client).to receive(:list_evaluations).and_return(mock_list_evaluations_response)
+    allow(mock_list_evaluations_response).to receive(:each).and_yield(evaluation_success).and_yield(evaluation_failure)
+  end
+
+  describe ".fetch_and_format" do
+    it "fetches all pages of results from the evaluations service" do
+      expected_output = <<~HEREDOC
+        FAILED
+        ==============
+        Sample query set: clickstream_2025-12
+        Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
+
+        SUCCEEDED
+        ==============
+        Sample query set: binary_2025-12
+        Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
+
+        PENDING
+        ==============
+        RUNNING
+        ==============
+      HEREDOC
+
+      expect { evaluation_reporter.fetch_and_format }.to output(expected_output).to_stdout
+    end
+  end
+end

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -27,12 +27,19 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
     double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec", query_set_spec: clickstream_query_set_spec)
   end
 
+  let(:timestamp_one) { double("Google::Protobuf::Timestamp", seconds: 1_763_535_606, nanos: 700_845_000) }
+  let(:timestamp_two) { double("Google::Protobuf::Timestamp", seconds: 1_763_536_521, nanos: 507_884_722) }
+  let(:timestamp_three) { double("Google::Protobuf::Timestamp", seconds: 1_758_096_006, nanos: 123_415_000) }
+  let(:timestamp_four) { double("Google::Protobuf::Timestamp", seconds: 1_758_097_403, nanos: 880_911_074) }
+
   let(:evaluation_success) do
     double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
            name: binary_evaluation_name,
            evaluation_spec: binary_evaluation_spec,
            state: :SUCCEEDED,
-           error: {})
+           error: {},
+           create_time: timestamp_one,
+           end_time: timestamp_two)
   end
 
   let(:evaluation_failure) do
@@ -40,7 +47,9 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
            name: clickstream_evaluation_name,
            evaluation_spec: clickstream_evaluation_spec,
            state: :FAILED,
-           error: { code: 13, message: "Internal error encountered. Please try again. If the issue persists, please contact our support team." })
+           error: { code: 13, message: "Internal error encountered. Please try again. If the issue persists, please contact our support team." },
+           create_time: timestamp_three,
+           end_time: timestamp_four)
   end
 
   let(:mock_client) { double(::Google::Cloud::DiscoveryEngine::V1beta::EvaluationService::Client) }
@@ -59,11 +68,13 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
         ==============
         Sample query set: clickstream_2025-12
         Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
+        Start time: 2025-09-17 08:00:06
 
         SUCCEEDED
         ==============
         Sample query set: binary_2025-12
         Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
+        Start time: 2025-11-19 07:00:06
 
         PENDING
         ==============

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -62,27 +62,51 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
   end
 
   describe ".fetch_and_format" do
-    it "fetches all pages of results from the evaluations service" do
-      expected_output = <<~HEREDOC
-        FAILED
-        ==============
-        Sample query set: clickstream_2025-12
-        Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
-        Start time: 2025-09-17 08:00:06
+    context "when no date string is passed in" do
+      it "prints out all pages of results from the evaluation service" do
+        expected_output = <<~HEREDOC
+          FAILED
+          ==============
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
+          Start time: 2025-09-17 08:00:06
 
-        SUCCEEDED
-        ==============
-        Sample query set: binary_2025-12
-        Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
-        Start time: 2025-11-19 07:00:06
+          SUCCEEDED
+          ==============
+          Sample query set: binary_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
+          Start time: 2025-11-19 07:00:06
 
-        PENDING
-        ==============
-        RUNNING
-        ==============
-      HEREDOC
+          PENDING
+          ==============
+          RUNNING
+          ==============
+        HEREDOC
 
-      expect { evaluation_reporter.fetch_and_format }.to output(expected_output).to_stdout
+        expect { evaluation_reporter.fetch_and_format }.to output(expected_output).to_stdout
+      end
+    end
+
+    context "when a 'YYYY-MM' date string is passed in" do
+      it "only prints out evaluations created during the year and month specified" do
+        expected_output = <<~HEREDOC
+          FAILED
+          ==============
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
+          Start time: 2025-09-17 08:00:06
+
+          SUCCEEDED
+          ==============
+          PENDING
+          ==============
+          RUNNING
+          ==============
+        HEREDOC
+
+        date_string = "2025-09"
+        expect { evaluation_reporter.fetch_and_format(date_string:) }.to output(expected_output).to_stdout
+      end
     end
   end
 end

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -1,7 +1,7 @@
 require "google/cloud/discovery_engine/v1beta"
 
 RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
-  let(:evaluation_reporter) { described_class.new }
+  let(:evaluation_reporter) { described_class }
 
   let(:binary_evaluation_name) { "projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3" }
 
@@ -100,7 +100,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           ==============
         HEREDOC
 
-        expect { evaluation_reporter.fetch_and_format }.to output(expected_output).to_stdout
+        expect { evaluation_reporter.new.fetch_and_format }.to output(expected_output).to_stdout
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
         HEREDOC
 
         date_string = "2025-09"
-        expect { evaluation_reporter.fetch_and_format(date_string:) }.to output(expected_output).to_stdout
+        expect { evaluation_reporter.new(date_string:).fetch_and_format }.to output(expected_output).to_stdout
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
         HEREDOC
 
         expect {
-          evaluation_reporter.fetch_and_format(states: %i[FAILED PENDING])
+          evaluation_reporter.new(states: %i[FAILED PENDING]).fetch_and_format
         }.to output(expected_output).to_stdout
       end
     end

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
   let(:evaluation_reporter) { described_class }
 
   let(:binary_evaluation_name) { "projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3" }
+  let(:another_binary_evaluation_name) { "projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b34123456" }
 
   let(:binary_set_name) { "projects/123456/locations/global/sampleQuerySets/binary_2025-12" }
 
@@ -28,6 +29,8 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
     double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec", query_set_spec: clickstream_query_set_spec)
   end
 
+  let(:quality_metrics) { double("Google::Cloud::DiscoveryEngine::V1beta::QualityMetrics", to_h: { "anything": "anything" }) }
+
   let(:timestamp_one) { double("Google::Protobuf::Timestamp", seconds: 1_763_535_606, nanos: 700_845_000) }
   let(:timestamp_two) { double("Google::Protobuf::Timestamp", seconds: 1_763_536_521, nanos: 507_884_722) }
   let(:timestamp_three) { double("Google::Protobuf::Timestamp", seconds: 1_758_096_006, nanos: 123_415_000) }
@@ -40,9 +43,21 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
            name: binary_evaluation_name,
            evaluation_spec: binary_evaluation_spec,
            state: :SUCCEEDED,
+           quality_metrics: quality_metrics,
            error: {},
            create_time: timestamp_one,
            end_time: timestamp_two)
+  end
+
+  let(:evaluation_success_two) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
+           name: another_binary_evaluation_name,
+           evaluation_spec: binary_evaluation_spec,
+           state: :SUCCEEDED,
+           quality_metrics: {},
+           error: {},
+           create_time: timestamp_three,
+           end_time: timestamp_four)
   end
 
   let(:evaluation_failure) do
@@ -71,7 +86,11 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
   before do
     allow(DiscoveryEngine::Clients).to receive(:evaluation_service).and_return(mock_client)
     allow(mock_client).to receive(:list_evaluations).and_return(mock_list_evaluations_response)
-    allow(mock_list_evaluations_response).to receive(:each).and_yield(evaluation_success).and_yield(evaluation_failure).and_yield(evaluation_failure_two)
+    allow(mock_list_evaluations_response).to receive(:each)
+      .and_yield(evaluation_success)
+      .and_yield(evaluation_success_two)
+      .and_yield(evaluation_failure)
+      .and_yield(evaluation_failure_two)
   end
 
   describe ".fetch_and_format" do
@@ -90,6 +109,11 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
 
           SUCCEEDED
           ==============
+          Sample query set: binary_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b34123456
+          Start time: 2025-09-17 08:00:06
+          No quality metrics!
+
           Sample query set: binary_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
           Start time: 2025-11-19 07:00:06
@@ -115,6 +139,11 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
 
           SUCCEEDED
           ==============
+          Sample query set: binary_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b34123456
+          Start time: 2025-09-17 08:00:06
+          No quality metrics!
+
           PENDING
           ==============
           RUNNING

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
   end
 
   let(:clickstream_evaluation_name) { "projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9" }
+  let(:another_clickstream_evaluation_name) { "projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-123456" }
 
   let(:clickstream_set_name) { "projects/123456/locations/global/sampleQuerySets/clickstream_2025-12" }
 
@@ -31,6 +32,8 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
   let(:timestamp_two) { double("Google::Protobuf::Timestamp", seconds: 1_763_536_521, nanos: 507_884_722) }
   let(:timestamp_three) { double("Google::Protobuf::Timestamp", seconds: 1_758_096_006, nanos: 123_415_000) }
   let(:timestamp_four) { double("Google::Protobuf::Timestamp", seconds: 1_758_097_403, nanos: 880_911_074) }
+  let(:timestamp_five) { double("Google::Protobuf::Timestamp", seconds: 1_782_468_026, nanos: 497_828_000) }
+  let(:timestamp_six) { double("Google::Protobuf::Timestamp", seconds: 1_782_468_035, nanos: 806_111_919) }
 
   let(:evaluation_success) do
     double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
@@ -52,13 +55,23 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
            end_time: timestamp_four)
   end
 
+  let(:evaluation_failure_two) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
+           name: another_clickstream_evaluation_name,
+           evaluation_spec: clickstream_evaluation_spec,
+           state: :FAILED,
+           error: { code: 13, message: "Internal error encountered. Please try again. If the issue persists, please contact our support team." },
+           create_time: timestamp_five,
+           end_time: timestamp_six)
+  end
+
   let(:mock_client) { double(::Google::Cloud::DiscoveryEngine::V1beta::EvaluationService::Client) }
   let(:mock_list_evaluations_response) { double(Gapic::PagedEnumerable) }
 
   before do
     allow(DiscoveryEngine::Clients).to receive(:evaluation_service).and_return(mock_client)
     allow(mock_client).to receive(:list_evaluations).and_return(mock_list_evaluations_response)
-    allow(mock_list_evaluations_response).to receive(:each).and_yield(evaluation_success).and_yield(evaluation_failure)
+    allow(mock_list_evaluations_response).to receive(:each).and_yield(evaluation_success).and_yield(evaluation_failure).and_yield(evaluation_failure_two)
   end
 
   describe ".fetch_and_format" do
@@ -70,6 +83,10 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
           Start time: 2025-09-17 08:00:06
+
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-123456
+          Start time: 2026-06-26 10:00:26
 
           SUCCEEDED
           ==============
@@ -117,6 +134,10 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
           Start time: 2025-09-17 08:00:06
+
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-123456
+          Start time: 2026-06-26 10:00:26
 
           PENDING
           ==============

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -108,5 +108,24 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
         expect { evaluation_reporter.fetch_and_format(date_string:) }.to output(expected_output).to_stdout
       end
     end
+
+    context "when a state is passed in" do
+      it "only prints out evaluations with a matching state" do
+        expected_output = <<~HEREDOC
+          FAILED
+          ==============
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
+          Start time: 2025-09-17 08:00:06
+
+          PENDING
+          ==============
+        HEREDOC
+
+        expect {
+          evaluation_reporter.fetch_and_format(states: %i[FAILED PENDING])
+        }.to output(expected_output).to_stdout
+      end
+    end
   end
 end

--- a/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_reporter_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
     double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation::EvaluationSpec", query_set_spec: clickstream_query_set_spec)
   end
 
+  let(:pending_evaluation_name) { "projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-891011" }
+
   let(:quality_metrics) { double("Google::Cloud::DiscoveryEngine::V1beta::QualityMetrics", to_h: { "anything": "anything" }) }
 
   let(:timestamp_one) { double("Google::Protobuf::Timestamp", seconds: 1_763_535_606, nanos: 700_845_000) }
@@ -80,6 +82,15 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
            end_time: timestamp_six)
   end
 
+  let(:evaluation_pending) do
+    double("Google::Cloud::DiscoveryEngine::V1beta::Evaluation",
+           name: pending_evaluation_name,
+           evaluation_spec: clickstream_evaluation_spec,
+           state: :PENDING,
+           error: { code: 13, message: "Internal error encountered. Please try again. If the issue persists, please contact our support team." },
+           create_time: timestamp_five)
+  end
+
   let(:mock_client) { double(::Google::Cloud::DiscoveryEngine::V1beta::EvaluationService::Client) }
   let(:mock_list_evaluations_response) { double(Gapic::PagedEnumerable) }
 
@@ -91,6 +102,7 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
       .and_yield(evaluation_success_two)
       .and_yield(evaluation_failure)
       .and_yield(evaluation_failure_two)
+      .and_yield(evaluation_pending)
   end
 
   describe ".fetch_and_format" do
@@ -102,24 +114,36 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
           Start time: 2025-09-17 08:00:06
+          End time: 2025-09-17 08:23:23
+          Duration: 23.296 mins
 
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-123456
           Start time: 2026-06-26 10:00:26
+          End time: 2026-06-26 10:00:35
+          Duration: 0.155 mins
 
           SUCCEEDED
           ==============
           Sample query set: binary_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b34123456
           Start time: 2025-09-17 08:00:06
+          End time: 2025-09-17 08:23:23
+          Duration: 23.296 mins
           No quality metrics!
 
           Sample query set: binary_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b3497ebf3
           Start time: 2025-11-19 07:00:06
+          End time: 2025-11-19 07:15:21
+          Duration: 15.247 mins
 
           PENDING
           ==============
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-891011
+          Start time: 2026-06-26 10:00:26
+
           RUNNING
           ==============
         HEREDOC
@@ -136,12 +160,16 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
           Start time: 2025-09-17 08:00:06
+          End time: 2025-09-17 08:23:23
+          Duration: 23.296 mins
 
           SUCCEEDED
           ==============
           Sample query set: binary_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0038a998-7424-4fa4-ac3c-f70b34123456
           Start time: 2025-09-17 08:00:06
+          End time: 2025-09-17 08:23:23
+          Duration: 23.296 mins
           No quality metrics!
 
           PENDING
@@ -163,13 +191,21 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsReporter do
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-66f4235ba4f9
           Start time: 2025-09-17 08:00:06
+          End time: 2025-09-17 08:23:23
+          Duration: 23.296 mins
 
           Sample query set: clickstream_2025-12
           Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-123456
           Start time: 2026-06-26 10:00:26
+          End time: 2026-06-26 10:00:35
+          Duration: 0.155 mins
 
           PENDING
           ==============
+          Sample query set: clickstream_2025-12
+          Evaluation: projects/123456/locations/global/evaluations/0392a80d-4c9b-433a-93a8-891011
+          Start time: 2026-06-26 10:00:26
+
         HEREDOC
 
         expect {


### PR DESCRIPTION
## What

Convenience rake task to help us obtain information for google support tickets when reporting on failed evaluations.

Depends on https://github.com/alphagov/search-api-v2-beta-features/pull/137

To run locally (against integration):

`govuk-docker run search-api-v2-beta-features-task-runner bundle exec rake report:evaluations\[2026-06,failed\]`

Example output:

```
FAILED
==============
Sample query set: binary_2026-05
Evaluation: projects/780375417592/locations/global/evaluations/ffc1320f-7042-4e80-9a4d-6d248ad5ad30
Start time: 2026-06-27 08:23:35
End time: 2026-06-27 08:23:40
Duration: 0.07511406283333333 mins

Sample query set: binary_2026-05
Evaluation: projects/780375417592/locations/global/evaluations/447fb39f-4644-479a-b650-0a9468026a3d
Start time: 2026-06-28 08:26:39
End time: 2026-06-28 08:26:42
Duration: 0.053512227833333335 mins

SUCCEEDED
==============
Sample query set: explicit_2026-06
Evaluation: projects/780375417592/locations/global/evaluations/e07fab77-f709-40fc-86a4-ac8cc029df27
Start time: 2026-06-30 03:00:11
End time: 2026-06-30 03:17:34
Duration: 17.384713683799998 mins
No quality metrics!
```
jira https://gov-uk.atlassian.net/browse/SCH-1786