### PR TITLE
Allow service account impersonation for local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ end
 
 group :development, :test do
   gem "brakeman", require: false
+  gem "googleauth", ">= 1.16.0"
   gem "govuk_test"
   gem "pry-byebug"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,6 +696,7 @@ DEPENDENCIES
   climate_control
   google-cloud-discovery_engine-v1beta
   google-cloud-storage
+  googleauth (>= 1.16.0)
   govuk_app_config
   govuk_test
   grpc_mock

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ govuk-docker run search-api-v2-beta-features-lite bundle exec rake
 
 ### Running rake tasks
 
+#### Prerequisites
+
+1. You must be a member of the integration gcp access google group: govuk-gcp-access-integration@digital.cabinet-office.gov.uk
+2. You will need the email address of the custom search-api-v2 integration service account. This is the service account used by Search API v2 beta features running in integration to authenticate its requests to Google's Discovery Engine API.
+The email address can be found under *IAM and admin > Service Accounts* in the __Search API V2 Integration__ project at https://console.cloud.google.com.
+
+Note: There are two similarly named service accounts. Make sure to select the account used to provide access to the search-api-v2 Rails app and document sync worker.
+
+```bash
+gcloud auth application-default login --impersonate-service-account <search-api-v2 service account email address>
+```
+
 Rake tasks can be run against the `task-runner` stack:
 
 ```bash

--- a/config/initializers/impersonated_service_account_credentials.rb
+++ b/config/initializers/impersonated_service_account_credentials.rb
@@ -1,0 +1,13 @@
+# This is a monkey patch to allow us to use impersonated service account credentials for local development with govuk-docker
+# https://github.com/googleapis/google-auth-library-ruby/issues/563
+module Google
+  module Auth
+    class ImpersonatedServiceAccountCredentials
+    private
+
+      def prepare_auth_header
+        @source_credentials.updater_proc.call({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for service account impersonation when running search api v2 beta features locally. 

`gcloud auth application-default login --impersonate-service-account <integration-service-account-email>`

This ADC contains a credential based on the permissions of the search-api-v2 integration service account.

Support for service account impersonation has only recently been added to the googleauth library [3] and there
is an open issue tracking a problem with creation of the auth_headers [4], hence the monkey patch.

    [1] https://github.com/alphagov/govuk-docker/blob/main/projects/search-api-v2/docker-compose.yml#L14
    [2] https://docs.cloud.google.com/docs/authentication/application-default-credentials#personal
    [3] https://github.com/googleapis/google-auth-library-ruby/blob/main/CHANGELOG.md#1160-2025-11-21
    [4] googleapis/google-auth-library-ruby#563

See https://github.com/alphagov/search-api-v2/pull/626 for prior art.