### PR TITLE
Sch 2262 update evaluations report cron job to be relative instead of fixed month

### DIFF
--- a/app/services/discovery_engine/quality/evaluations_reporter.rb
+++ b/app/services/discovery_engine/quality/evaluations_reporter.rb
@@ -1,5 +1,7 @@
 module DiscoveryEngine::Quality
   class EvaluationsReporter
+    VALID_STATES = %i[FAILED SUCCEEDED PENDING RUNNING].freeze
+
     # date_string format is "2026-02"
     def initialize(date_string: nil, states: [])
       @date_string = date_string
@@ -9,12 +11,7 @@ module DiscoveryEngine::Quality
     attr_reader :date_string, :states
 
     def fetch_and_format
-      evaluations_grouped_by_state = {
-        FAILED: [],
-        SUCCEEDED: [],
-        PENDING: [],
-        RUNNING: [],
-      }
+      evaluations_grouped_by_state = VALID_STATES.index_with { [] }
 
       if states.present?
         evaluations_grouped_by_state.select! { |k, _v| states.include?(k) }

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -10,7 +10,6 @@ namespace :report do
   desc "Output evaluations report"
   task :evaluations, %i[date_string states] => :environment do |_, args|
     valid_date_regex = /^\d{4}-\d{2}$/
-    valid_states = DiscoveryEngine::Quality::EvaluationsReporter::VALID_STATES
 
     if args[:date_string]
       date_string = args[:date_string]
@@ -18,10 +17,19 @@ namespace :report do
     end
 
     if args[:states]
-      states = args[:states].split(" ").map { |arg| arg.upcase.to_sym }
-      raise "state must be one of #{valid_states.to_sentence}" unless (states - valid_states).empty?
+      states = split_and_validate_states(args[:states])
     end
 
     DiscoveryEngine::Quality::EvaluationsReporter.new(date_string:, states:).fetch_and_format
   end
+end
+
+def split_and_validate_states(states)
+  return unless states
+
+  valid_states = DiscoveryEngine::Quality::EvaluationsReporter::VALID_STATES
+  split_states = states.split(" ").map { |arg| arg.upcase.to_sym }
+  raise "state must be one of #{valid_states.to_sentence}" unless (split_states - valid_states).empty?
+
+  split_states
 end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -10,7 +10,7 @@ namespace :report do
   desc "Output evaluations report"
   task :evaluations, %i[date_string states] => :environment do |_, args|
     valid_date_regex = /^\d{4}-\d{2}$/
-    valid_states = %i[FAILED PENDING RUNNING SUCCEEDED]
+    valid_states = DiscoveryEngine::Quality::EvaluationsReporter::VALID_STATES
 
     if args[:date_string]
       date_string = args[:date_string]

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,12 +1,11 @@
 namespace :report do
   # Outputs a list of evaluations of GOV.UK site search quality fetched from the Google DiscoveryEngine API's evaluations endpoint.
-  #  The task can be called with no arguments, or with two arguments.
+  # The task can be called with no arguments, or with two arguments.
   # Example usage:
   # rake report:evaluations['2026-06','failed pending'] will fetch pending and failed evaluations created in June 2026.
   # rake report:evaluations['','failed pending'] will fetch all failed and pending evaluations
   # rake report:evaluations['2026-06',''] will fetch all evaluations created in June 2026
   # rake report:evaluations will fetch all evaluations
-
   desc "Output evaluations report"
   task :evaluations, %i[date_string states] => :environment do |_, args|
     valid_date_regex = /^\d{4}-\d{2}$/
@@ -19,6 +18,34 @@ namespace :report do
     if args[:states]
       states = split_and_validate_states(args[:states])
     end
+
+    DiscoveryEngine::Quality::EvaluationsReporter.new(date_string:, states:).fetch_and_format
+  end
+
+  # Outputs a list of evaluations of GOV.UK site search quality, which have been run during the current month.
+  # These are fetched from the Google DiscoveryEngine API's evaluations endpoint.
+  # The task can be called with no arguments, or with a string input representing a list of relevant states.
+  # Example usage:
+  # rake report:evaluations['failed pending'] will fetch all failed and pending evaluations run this month.
+  # rake report:evaluations will fetch all evaluations that have been run during the current month.
+  desc "Output evaluations report for this month"
+  task :evaluations_this_month, %i[states] => :environment do |_, args|
+    date_string = Time.zone.now.strftime("%Y-%m")
+    states = split_and_validate_states(args[:states])
+
+    DiscoveryEngine::Quality::EvaluationsReporter.new(date_string:, states:).fetch_and_format
+  end
+
+  # Outputs a list of evaluations of GOV.UK site search quality, which have been run during the last calendar month.
+  # These are fetched from the Google DiscoveryEngine API's evaluations endpoint.
+  # The task can be called with no arguments, or with a string input representing a list of relevant states.
+  # Example usage:
+  # rake report:evaluations['failed pending'] will fetch all failed and pending evaluations run last month.
+  # rake report:evaluations will fetch all evaluations that have been run during the last calendar month.
+  desc "Output evaluations report for last month"
+  task :evaluations_last_month, %i[states] => :environment do |_, args|
+    date_string = Time.zone.now.prev_month.strftime("%Y-%m")
+    states = split_and_validate_states(args[:states])
 
     DiscoveryEngine::Quality::EvaluationsReporter.new(date_string:, states:).fetch_and_format
   end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -1,16 +1,17 @@
 RSpec.describe "Report tasks" do
+  let(:reporter) { instance_double(DiscoveryEngine::Quality::EvaluationsReporter) }
+
+  before do
+    task.reenable
+    allow(DiscoveryEngine::Quality::EvaluationsReporter)
+      .to receive(:new)
+      .with(anything)
+      .and_return(reporter)
+    allow(reporter).to receive(:fetch_and_format)
+  end
+
   describe "report:evaluations" do
-    let(:reporter) { instance_double(DiscoveryEngine::Quality::EvaluationsReporter) }
     let(:task) { Rake::Task["report:evaluations"] }
-
-    before do
-      task.reenable
-
-      allow(DiscoveryEngine::Quality::EvaluationsReporter).to receive(:new)
-        .with(anything)
-        .and_return(reporter)
-      allow(reporter).to receive(:fetch_and_format)
-    end
 
     it "does not require arguments" do
       expect { task.invoke }.not_to raise_error
@@ -20,8 +21,56 @@ RSpec.describe "Report tasks" do
       expect { task.invoke("2027-1") }.to raise_error(RuntimeError)
     end
 
-    it "raises an error if the format is not valid" do
+    it "raises an error if the states are not valid" do
       expect { task.invoke("", "invalid") }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "report:evaluations_this_month" do
+    let(:task) { Rake::Task["report:evaluations_this_month"] }
+
+    around do |example|
+      Timecop.freeze(2026, 2, 8) { example.call }
+    end
+
+    it "does not require arguments" do
+      expect { task.invoke }.not_to raise_error
+    end
+
+    it "calls evaluations reporter for this month" do
+      task.invoke
+
+      expect(DiscoveryEngine::Quality::EvaluationsReporter)
+        .to have_received(:new)
+        .with(date_string: "2026-02", states: nil)
+    end
+
+    it "raises an error if the states are not valid" do
+      expect { task.invoke("invalid") }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "report:evaluations_last_month" do
+    let(:task) { Rake::Task["report:evaluations_last_month"] }
+
+    around do |example|
+      Timecop.freeze(2026, 2, 8) { example.call }
+    end
+
+    it "does not require arguments" do
+      expect { task.invoke }.not_to raise_error
+    end
+
+    it "calls evaluations reporter for last month" do
+      task.invoke
+
+      expect(DiscoveryEngine::Quality::EvaluationsReporter)
+        .to have_received(:new)
+        .with(date_string: "2026-01", states: nil)
+    end
+
+    it "raises an error if the states are not valid" do
+      expect { task.invoke("invalid") }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
Adds new rake tasks to report on evaluations for this month and last month.

Since search-api-v2-beta-features doesn’t have a live deployment, it’s not straightforward to run rake tasks ad-hoc. The best we can do is set up a cron job, which can be run manually as needed. These new rake tasks mean that we can have the cron jobs stay relevant month-on-month, rather than having to update them (to edit the input month) each month.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2262